### PR TITLE
feat: add hero image to vending page

### DIFF
--- a/vending.html
+++ b/vending.html
@@ -56,17 +56,19 @@
 
   <a href="/contact.html" class="btn sticky-cta">Get a Quote</a>
 
-<main class="container section">
-  <h1>Vending & Micro-Markets</h1>
-  <p>Smart, cashless machines with product mix tuned to your traffic. We handle placement, restock, and support.</p>
-  <ul class="list">
-    <li>Card &amp; mobile payments</li>
-    <li>Healthy snacks + local favorites</li>
-    <li>24/7 monitoring &amp; refill</li>
-  </ul>
-  <p style="margin-top:1.2rem">
-    <a class="btn" href="/contact.html">Request vending</a>
-  </p>
+<main class="hero">
+  <div class="container hero-inner">
+    <h1>Vending & Micro-Markets</h1>
+    <p>Smart, cashless machines with product mix tuned to your traffic. We handle placement, restock, and support.</p>
+    <ul class="list">
+      <li>Card &amp; mobile payments</li>
+      <li>Healthy snacks + local favorites</li>
+      <li>24/7 monitoring &amp; refill</li>
+    </ul>
+    <p style="margin-top:1.2rem">
+      <a class="btn" href="/contact.html">Request vending</a>
+    </p>
+  </div>
 </main>
 
 <footer class="footer">


### PR DESCRIPTION
## Summary
- display hero background on vending & micro markets page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5cca9b8483279f22ee99e94b8480