### PR TITLE
feat: add tile gallery for vending machines

### DIFF
--- a/assets/css/three-up-tiles.css
+++ b/assets/css/three-up-tiles.css
@@ -1,0 +1,77 @@
+/* === 3-tile gallery (vending & micro-markets) === */
+
+:root {
+  --tiles-gap: clamp(12px, 2vw, 24px);
+  --tiles-radius: 16px;
+}
+
+.tiles-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--tiles-gap);
+  align-items: stretch;
+}
+
+/* Tile base */
+.tile {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--tiles-radius);
+  background: #f2f2f2;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.08);
+}
+
+/* Fixed, consistent height for all images */
+.tile .media {
+  width: 100%;
+  height: clamp(320px, 55vh, 520px);
+}
+
+/* Cover the area without distortion */
+.tile img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transform: scale(1);
+  transition: transform .5s ease;
+}
+
+/* Subtle dark-to-transparent overlay for optional captions */
+.tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,.45), rgba(0,0,0,0) 60%);
+  opacity: .55;
+  pointer-events: none;
+  transition: opacity .3s ease;
+}
+
+/* Optional label (put text in .label) */
+.tile .label {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  color: #fff;
+  font-weight: 600;
+  font-size: clamp(16px, 2vw, 20px);
+  text-shadow: 0 1px 2px rgba(0,0,0,.5);
+  z-index: 1;
+}
+
+/* Make whole tile clickable by wrapping with <a class="tile-link"> or using <a> inside */
+.tile > a.tile-link { position: absolute; inset: 0; z-index: 2; }
+
+/* Hover polish */
+.tile:hover img { transform: scale(1.04); }
+.tile:hover::after { opacity: .72; }
+
+/* Responsive: 2-up on tablets, 1-up on phones */
+@media (max-width: 1024px) {
+  .tiles-3 { grid-template-columns: repeat(2, minmax(0,1fr)); }
+}
+@media (max-width: 640px) {
+  .tiles-3 { grid-template-columns: 1fr; }
+  .tile .media { height: clamp(260px, 48vh, 440px); }
+}

--- a/vending.html
+++ b/vending.html
@@ -23,6 +23,7 @@
 
   <!-- Styles & scripts -->
   <link rel="stylesheet" href="/assets/css/style.css" />
+  <link rel="stylesheet" href="/assets/css/three-up-tiles.css" />
   <script defer src="/assets/js/main.js"></script>
 
   <!-- Schema.org -->
@@ -75,22 +76,31 @@
   <h2 id="machines">Machines in the field</h2>
   <p>We deploy modern, cashless snack and beverage machines and can scale up to micro‑markets for higher‑traffic locations. Hardware is monitored 24/7 and stocked with a mix tailored to your team.</p>
 
-  <div class="grid">
-    <figure class="card" style="text-align:center">
-      <img src="/assets/img/crane15.png" alt="Crane National 15 snack machine" loading="lazy" decoding="async" style="max-width:100%;border-radius:12px" />
-      <figcaption style="margin-top:.5rem;color:var(--muted)">Crane National 15 — compact snack lineup</figcaption>
-    </figure>
+    <section class="tiles-3">
+      <div class="tile">
+        <div class="media">
+          <img src="/assets/img/crane15.png" alt="Crane National 15 snack machine" loading="lazy" decoding="async">
+        </div>
+        <div class="label">Crane National 15</div>
+        <a class="tile-link" href="/assets/img/crane15.png"></a>
+      </div>
 
-    <figure class="card" style="text-align:center">
-      <img src="/assets/img/dixienarco.jpg" alt="Dixie‑Narco beverage vending machine" loading="lazy" decoding="async" style="max-width:100%;border-radius:12px" />
-      <figcaption style="margin-top:.5rem;color:var(--muted)">Dixie‑Narco — cold drinks with cashless payments</figcaption>
-    </figure>
+      <div class="tile">
+        <div class="media">
+          <img src="/assets/img/dixienarco.jpg" alt="Dixie-Narco beverage vending machine" loading="lazy" decoding="async">
+        </div>
+        <div class="label">Dixie-Narco</div>
+        <a class="tile-link" href="/assets/img/dixienarco.jpg"></a>
+      </div>
 
-    <figure class="card" style="text-align:center">
-      <img src="/assets/img/futura-3589.jpg" alt="Futura 3589 snack vending machine" loading="lazy" decoding="async" style="max-width:100%;border-radius:12px" />
-      <figcaption style="margin-top:.5rem;color:var(--muted)">Futura 3589 — high‑capacity snacks</figcaption>
-    </figure>
-  </div>
+      <div class="tile">
+        <div class="media">
+          <img src="/assets/img/futura-3589.jpg" alt="Futura 3589 snack vending machine" loading="lazy" decoding="async">
+        </div>
+        <div class="label">Futura 3589</div>
+        <a class="tile-link" href="/assets/img/futura-3589.jpg"></a>
+      </div>
+    </section>
 
   <p style="margin-top:1rem">
     <a class="btn" href="/contact.html">Place a machine</a>


### PR DESCRIPTION
## Summary
- introduce three-up tile gallery styles
- showcase vending machines with new tiled layout

## Testing
- `npx --yes htmlhint vending.html` (fails: 403 Forbidden retrieving htmlhint from npm registry)


------
https://chatgpt.com/codex/tasks/task_e_68bb56dc2c6883279b409597773d0d24